### PR TITLE
Change to make hidden lines un-editable

### DIFF
--- a/ExtendedPublicTransportUI/TransportUtil.cs
+++ b/ExtendedPublicTransportUI/TransportUtil.cs
@@ -18,10 +18,12 @@ namespace EPTUI
         public static void HideTransportLine(ushort lineID)
         {
             Tm.m_lines.m_buffer[lineID].m_flags |= TransportLine.Flags.Hidden;
+			Tm.m_lines.m_buffer[lineID].m_flags &= ~TransportLine.Flags.Created;
         }
         public static void ShowTransportLine(ushort lineID)
         {
             Tm.m_lines.m_buffer[lineID].m_flags &= ~TransportLine.Flags.Hidden;
+			Tm.m_lines.m_buffer[lineID].m_flags |= TransportLine.Flags.Created;
         }
 
         public static void SelectTransportLine(ushort lineID)


### PR DESCRIPTION
Fix is based on the fact that TransportManager.Raycast (which is the method used to select which line the user is editing) doesn't take into account the TransportLine.Flags.Hidden flag, but DOES take into account TransportLine.Flags.Created flag.  I'm honestly not sure what TransportLine.Flags.Created is used for after a line has been completed (it seems like that's the only time it's important), but with a small amount of testing, this appears to fix the known issue of hidden lines becoming visible again when hovered over and doesn't seem to create any other issues.  Preferably needs further testing on other boxes before being released to the workshop.

This is my first github pull request, so if I did anything wrong here let me know and I'll do what I can to fix it.
